### PR TITLE
Update for ember-cli only usage and HTMLBars compatibility

### DIFF
--- a/addon.js
+++ b/addon.js
@@ -1,12 +1,12 @@
 var inlineTemplateCompiler = require('./index');
 
 module.exports = {
-  name: 'broccoli-ember-inline-template-compiler',
+  name: 'ember-cli-inline-template-compiler',
   included: function(app) {
     this._super.included.apply(this, arguments);
 
     app.registry.add('js', {
-      name: 'broccoli-ember-inline-template-compiler',
+      name: 'ember-cli-inline-template-compiler',
       ext: 'js',
       toTree: function(tree) {
         return inlineTemplateCompiler(tree);

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var fs = require('fs');
 var path = require('path');
 var Filter = require('broccoli-filter');
-var compiler = require('ember-template-compiler');
+var compiler = require('../../bower_components/ember/ember-template-compiler.js');
 
 module.exports = EmberInlineTemplatePrecompiler;
 EmberInlineTemplatePrecompiler.prototype = Object.create(Filter.prototype);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "broccoli-ember-inline-template-compiler",
+  "name": "ember-cli-inline-template-compiler",
   "version": "0.0.1",
-  "description": "Broccoli plugin to precompile inline Handlebars templates",
+  "description": "ember cli plugin to precompile inline HTMLBars templates",
   "main": "index.js",
   "ember-addon": {
     "main": "addon.js"
@@ -19,7 +19,6 @@
   ],
   "dependencies": {
     "broccoli": "0.13.0",
-    "broccoli-filter": "0.1.7",
-    "ember-template-compiler": "1.9.0-alpha"
+    "broccoli-filter": "0.1.7"
   }
 }


### PR DESCRIPTION
@rwjblue for discussion only - this is a quick hack I applied while upgrading to ember 1.10 and HTMLBars

I recognize that it's no longer general purpose for a broc plugin as it depends on the ember-cli structure - hence the proposed rename

I'm using it and it works - thoughts on forking to ember-cli-inline-template-compiler? alternatives?
