### PR TITLE
Always prefer the ember-cli version of ember-template-compiler when used...

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ tree = inlineTemplateCompiler(tree);
 
 No changes to your `Brocfile.js`
 
+When used in an ember-cli project, this addon will use the current version of ember-template-compiler from your ember dependency
+
 ### Credits
 
 Extracted from https://github.com/emberjs/ember.js/blob/master/lib/broccoli-ember-inline-template-precompiler.js. Authored by [@rwjblue](https://github.com/rwjblue), [@fivetanley](https://github.com/fivetanley), and [@concreted](https://github.com/concreted).

--- a/addon.js
+++ b/addon.js
@@ -1,4 +1,7 @@
 var inlineTemplateCompiler = require('./index');
+var path = require('path');
+// for ember-cli always use the bower version of the ember template compiler
+var compiler = require(path.join(process.cwd(),'./bower_components/ember/ember-template-compiler.js'));
 
 module.exports = {
   name: 'broccoli-ember-inline-template-compiler',
@@ -9,7 +12,9 @@ module.exports = {
       name: 'broccoli-ember-inline-template-compiler',
       ext: 'js',
       toTree: function(tree) {
-        return inlineTemplateCompiler(tree);
+        return inlineTemplateCompiler(tree, { 
+          compiler: compiler
+        });
       }
     });
   }

--- a/index.js
+++ b/index.js
@@ -1,16 +1,15 @@
 /*jshint node: true */
 var fs = require('fs');
-var path = require('path');
 var Filter = require('broccoli-filter');
-var compiler = require('ember-template-compiler');
 
 module.exports = EmberInlineTemplatePrecompiler;
 EmberInlineTemplatePrecompiler.prototype = Object.create(Filter.prototype);
 EmberInlineTemplatePrecompiler.prototype.constructor = EmberInlineTemplatePrecompiler;
-function EmberInlineTemplatePrecompiler (inputTree) {
+function EmberInlineTemplatePrecompiler (inputTree, options) {
   if (!(this instanceof EmberInlineTemplatePrecompiler)) return new EmberInlineTemplatePrecompiler(inputTree);
 
   this.inputTree = inputTree;
+  this.compiler = options && options.compiler || require('ember-template-compiler');
   this.inlineTemplateRegExp = /precompileTemplate\(['"](.*)['"]\)/;
   // Used for replacing the original variable declaration to satisfy JSHint.
   // For example, removes `var precompileTemplate = Ember.Handlebars.compile;`.
@@ -35,7 +34,7 @@ EmberInlineTemplatePrecompiler.prototype.processFile = function (srcDir, destDir
 
     while (nextIndex > -1) {
       var match = inputString.match(self.inlineTemplateRegExp);
-      var template = "Ember.Handlebars.template(" + compiler.precompile(match[1], false) + ")";
+      var template = "Ember.Handlebars.template(" + self.compiler.precompile(match[1], false) + ")";
 
       inputString = inputString.replace(match[0], template);
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Broccoli plugin to precompile inline Handlebars templates",
   "main": "index.js",
   "ember-addon": {
-    "main": "addon.js"
+    "main": "addon.js",
+    "before": ["ember-cli-6to5"]
   },
   "author": "Robert Jackson",
   "license": "MIT",


### PR DESCRIPTION
... as an ember-cli addon
