### PR TITLE
Backwards compatible update to HTMLBars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ Example:
   var template = Ember.Handlebars.compile("...");
 
   // do
-  var precompileTemplate = Ember.Handlebars.compile;
+  var precompileTemplate = Ember.HTMLBars.compile;
   var template = precompileTemplate("...");
+```
+
+You can also use the compiler in the Handlebars namespace by changing your `precompileTemplate` definition:
+
+```javascript
+  var precompileTemplate = Ember.Handlebars.compile;
 ```
 
 ### Installation (as Broccoli plugin)


### PR DESCRIPTION
This turns the switch to HTMLBars into an opt-in approach, based upon the way the user defined `precompileTemplate`. This should be seen as an alternative to PR #8 with the bonus of being backwards compatible.
